### PR TITLE
bypass login if no password set

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --password value, -p value  if not set, any password will be accepted
+   --password value, -p value  if not set, qBittorrent will login automatically
    --uds value                 qBittorrent unix domain socket(uds) path (default: "/home/admin/qbt.sock")
    --debug, -d                 (default: false)
    --port value                proxy running port (default: 8080)
    --help, -h                  show help
 ```
 
-运行后，访问 `http://{host}:8080` 即可进入 qBittorrent WebUI。默认情况下用户名为 `admin`，输入任意密码均可访问，如果通过 `--password` 指定了密码，则只有该密码可访问；`--port` 修改运行端口
+运行后，访问 `http://{host}:8080` 即可进入 qBittorrent WebUI。默认情况会自动登录，如果通过 `--password` 指定了密码，则只有该密码可访问；`--port` 修改运行端口
 ```bash
 $ ./fnos-qb-proxy --uds "/home/admin/qbt.sock"
 proxy running on port 8080

--- a/main.go
+++ b/main.go
@@ -37,7 +37,8 @@ func fetchQbPassword() (string, error) {
 	return "", fmt.Errorf("no qbittorrent-nox process found")
 }
 
-func fetchQbSid(uds string, password string) (string, error) {
+// login to qBittorrent and return SID cookie value
+func login(uds string, password string) (string, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -97,7 +98,7 @@ func proxyCmd(ctx *cli.Context) error {
 		if expectedPassword != "" {
 			return ""
 		}
-		sid, err := fetchQbSid(uds, password)
+		sid, err := login(uds, password)
 		if err != nil {
 			fmt.Printf("fetch qbittorrent-nox sid: %v\n", err)
 		}
@@ -190,7 +191,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "password",
 				Aliases: []string{"p"},
-				Usage:   "if not set, any password will be accepted",
+				Usage:   "if not set, qBittorrent will login automatically",
 				Value:   "",
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
if no password param is set, it is non-sense and a waste of time to input arbitrary user and password at the login page.

This PR can automatically fetch the login cookie `SID` and attach it to the proxied request to ensure no auth redirect anymore.


